### PR TITLE
Filter

### DIFF
--- a/src/Plugin/AccessControlHierarchy/Menu.php
+++ b/src/Plugin/AccessControlHierarchy/Menu.php
@@ -20,6 +20,7 @@ use Drupal\Core\Menu\MenuLinkManagerInterface;
 use Drupal\Core\Menu\MenuLinkTreeElement;
 use Drupal\Core\Menu\MenuLinkTreeInterface;
 use Drupal\Core\Menu\MenuTreeParameters;
+use Drupal\Core\Menu\MenuTreeStorageInterface;
 
 /**
  * Defines a hierarchy based on a Menu.
@@ -51,10 +52,12 @@ class Menu extends AccessControlHierarchyBase {
           'parents' => [],
           'weight' => 0,
           'description' => $menu->label(),
+          'id' => $id,
         );
         $params = new MenuTreeParameters();
         $data = $this->menuTree->load($id, $params);
-        $tree = $this->buildTree($id, $data, $tree);
+        $map = $this->loadMenuLinkData($id);
+        $tree = $this->buildTree($id, $data, $map, $tree);
       }
     }
     return $tree;
@@ -69,16 +72,19 @@ class Menu extends AccessControlHierarchyBase {
    *   The root id of the section tree.
    * @param array $data
    *   An array of menu tree or subtree data.
+   * @param array $map
+   *   An array of menu information, key is string id, value is integer mlid.
    * @param array &$tree
    *   The computed tree array to return.
    *
    * @return array $tree
    *   The compiled tree data.
    */
-  public function buildTree($id, $data, &$tree) {
+  public function buildTree($id, $data, $map, &$tree) {
     foreach ($data as $link_id => $link) {
-      $tree[$id][$link_id] = array(
-        'id' => $link_id,
+      $mlid = $map[$link_id];
+      $tree[$id][$mlid] = array(
+        'id' => $mlid, // This is the numeric mlid.
         'label' => $link->link->getTitle(),
         'depth' => $link->depth,
         'parents' => [],
@@ -87,14 +93,14 @@ class Menu extends AccessControlHierarchyBase {
       );
       // Get the parents.
       if ($parent = $link->link->getParent()) {
-        $tree[$id][$link_id]['parents'] = array_merge($tree[$id][$link_id]['parents'], [$parent]);
-        $tree[$id][$link_id]['parents'] = array_merge($tree[$id][$link_id]['parents'], $tree[$id][$parent]['parents']);
+        $tree[$id][$mlid]['parents'] = array_merge($tree[$id][$mlid]['parents'], [$map[$parent]]);
+        $tree[$id][$mlid]['parents'] = array_merge($tree[$id][$mlid]['parents'], $tree[$id][$map[$parent]]['parents']);
       }
       else {
-        $tree[$id][$link_id]['parents'] = [$id];
+        $tree[$id][$mlid]['parents'] = [$id];
       }
       if (isset($link->subtree)) {
-        $this->buildTree($id, $link->subtree, $tree);
+        $this->buildTree($id, $link->subtree, $map, $tree);
       }
     }
     return $tree;
@@ -138,10 +144,16 @@ class Menu extends AccessControlHierarchyBase {
    * {@inheritdoc}
    */
   public function getEntityValues(EntityInterface $entity, $field) {
+    static $map;
     $values = array();
     $defaults = menu_ui_get_menu_link_defaults($entity);
+    // Because the default menu system doesn't return mlids, we have to do some
+    // handstands.
     if (!empty($defaults['id'])) {
-      $values = [$defaults['id']];
+      if (!isset($map[$defaults['menu_name']])) {
+        $map[$defaults['menu_name']] = $this->loadMenuLinkData($defaults['menu_name']);
+      }
+      $values = [$map[$defaults['menu_name']][$defaults['id']]];
     }
     return $values;
   }
@@ -179,10 +191,28 @@ class Menu extends AccessControlHierarchyBase {
        'left_query' => "CONCAT('{$table}=', {$alias}.{$key})",
        'operator' => '=',
        'table_alias' => 'menu_tree',
-       'real_field' => 'id',
+       'real_field' => 'mlid',
       ];
     }
     return $configuration;
+  }
+
+  /**
+   * Loads menu data that include mlids, which we need for storage.
+   *
+   * @param $id
+   *   The root id of the section tree.
+   *
+   * @return array
+   *   An array of menu information, key is string id, value is integer mlid.
+   */
+  private function loadMenuLinkData($id) {
+    $storage = \Drupal::getContainer()->get('menu.tree_storage');
+    $data = $storage->loadByProperties(['menu_name' => $id]);
+    foreach ($data as $link) {
+      $map[$link['id']] = $link['mlid'];
+    }
+    return $map;
   }
 
 }

--- a/src/Plugin/views/filter/Section.php
+++ b/src/Plugin/views/filter/Section.php
@@ -59,6 +59,7 @@ class Section extends ManyToOne {
     $options['operator']['default'] = 'in';
     $options['value']['default'] = array('All');
     $options['expose']['contains']['reduce'] = array('default' => TRUE);
+    $options['section_filter']['show_hierarchy'] = TRUE;
 
     return $options;
   }
@@ -92,6 +93,19 @@ class Section extends ManyToOne {
       ),
     );
     return $operators;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildOptionsForm(&$form, FormStateInterface $form_state) {
+    parent::buildOptionsForm($form, $form_state);
+    $form['section_filter']['show_hierarchy'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Show children'),
+      '#default_value' => $this->options['section_filter']['show_hierarchy'],
+      '#description' => $this->t('If checked, the filter will return the selected item and all its children.'),
+    ];
   }
 
   /**
@@ -167,7 +181,12 @@ class Section extends ManyToOne {
       }
       // If 'All' was not selected, fetch the query values.
       if (!isset($values)) {
-        $values = $this->getChildren();
+        if (!empty($this->options['section_filter']['show_hierarchy'])) {
+          $values = $this->getChildren();
+        }
+        else {
+          $values = $this->value;
+        }
       }
       // If values, add our standard where clause.
       if (!empty($values)) {

--- a/src/Plugin/views/filter/Section.php
+++ b/src/Plugin/views/filter/Section.php
@@ -51,41 +51,6 @@ class Section extends ManyToOne {
   }
 
   /**
-   * When using exposed filters, we may be required to reduce the set.
-   */
-  public function reduceValueOptions($input = NULL) {
-    if (!isset($input)) {
-      $input = $this->valueOptions;
-    }
-    // If all, use what was provided.
-    if (empty($this->value) || strtolower(current($this->value)) == 'all') {
-      return $input;
-    }
-
-    // Because options may be an array of strings, or an array of mixed arrays
-    // and strings (optgroups) or an array of objects, we have to
-    // step through and handle each one individually.
-    $options = array();
-    foreach ($input as $id => $option) {
-      if (is_array($option)) {
-        $options[$id] = $this->reduceValueOptions($option);
-        continue;
-      }
-      elseif (is_object($option)) {
-        $keys = array_keys($option->option);
-        $key = array_shift($keys);
-        if (isset($this->options['value'][$key])) {
-          $options[$id] = $option;
-        }
-      }
-      elseif (isset($this->options['value'][$id])) {
-        $options[$id] = $option;
-      }
-    }
-    return $options;
-  }
-
-  /**
    * {@inheritdoc}
    */
   protected function defineOptions() {

--- a/src/WorkbenchAccessManager.php
+++ b/src/WorkbenchAccessManager.php
@@ -99,6 +99,7 @@ class WorkbenchAccessManager extends DefaultPluginManager implements WorkbenchAc
    * {@inheritdoc}
    */
   public function getUserSections($uid = NULL, $add_roles = TRUE) {
+    $user_sections = [];
     // Get the information from the account.
     if (is_null($uid)) {
       $uid = \Drupal::currentUser()->id();
@@ -121,6 +122,32 @@ class WorkbenchAccessManager extends DefaultPluginManager implements WorkbenchAc
     }
 
     return array_unique($user_sections);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function userInAll($uid = NULL) {
+    $return = FALSE;
+    // Get the information from the account.
+    if (is_null($uid)) {
+      $uid = \Drupal::currentUser()->id();
+    }
+    $user = \Drupal::entityTypeManager()->getStorage('user')->load($uid);
+    if ($user->hasPermission('bypass workbench access')) {
+      $return = TRUE;
+    }
+    else {
+      // If the user is assigned to all the top-level sections, treat as admin.
+      $user_sections = $this->getUserSections($uid);
+      foreach (array_keys($this->getActiveTree()) as $root) {
+        $return = TRUE;
+        if (empty($user_sections[$root])) {
+          $return = FALSE;
+        }
+      }
+    }
+    return $return;
   }
 
   /**

--- a/src/WorkbenchAccessManagerInterface.php
+++ b/src/WorkbenchAccessManagerInterface.php
@@ -199,4 +199,18 @@ interface WorkbenchAccessManagerInterface {
    */
   public function getUserSections($uid = NULL, $add_roles = TRUE);
 
+  /**
+   * Determines if a user is assigned to all sections.
+   *
+   * This method checks the permissions and assignments for a user. Someone set
+   * as an admin or with access to the top-level sections is assumed to be able
+   * to access all sections. We use this logic in query filtering.
+   *
+   * @param $uid
+   *   An optional user id. If not provided, the active user is returned.
+   *
+   * @return boolean
+   */
+  public function userInAll($uid = NULL);
+
 }

--- a/src/WorkbenchAccessMenuStorage.php
+++ b/src/WorkbenchAccessMenuStorage.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\workbench_access\WorkbenchAccessMenuStorage.
+ */
+
+namespace Drupal\workbench_access;
+
+use Drupal\Core\Menu\MenuTreeStorage;
+use Drupal\Core\Menu\MenuTreeStorageInterface;
+
+/**
+ * Overrides the default menu tree storage so we can access private data.
+ */
+
+class WorkbenchAccessMenuStorage extends MenuTreeStorage implements MenuTreeStorageInterface {
+
+  /**
+   * List of plugin definition fields.
+   *
+   * @todo Decide how to keep these field definitions in sync.
+   *   https://www.drupal.org/node/2302085
+   *
+   * @see \Drupal\Core\Menu\MenuLinkManager::$defaults
+   *
+   * @var array
+   */
+  protected $definitionFields = array(
+    'menu_name',
+    'mlid',
+    'route_name',
+    'route_parameters',
+    'url',
+    'title',
+    'description',
+    'parent',
+    'weight',
+    'options',
+    'expanded',
+    'enabled',
+    'provider',
+    'metadata',
+    'class',
+    'form_class',
+    'id',
+  );
+
+}

--- a/src/WorkbenchAccessMenuStorage.php
+++ b/src/WorkbenchAccessMenuStorage.php
@@ -18,8 +18,7 @@ class WorkbenchAccessMenuStorage extends MenuTreeStorage implements MenuTreeStor
   /**
    * List of plugin definition fields.
    *
-   * @todo Decide how to keep these field definitions in sync.
-   *   https://www.drupal.org/node/2302085
+   * We override the base class just to add 'mlid' to this array.
    *
    * @see \Drupal\Core\Menu\MenuLinkManager::$defaults
    *

--- a/src/WorkbenchAccessMenuStorage.php
+++ b/src/WorkbenchAccessMenuStorage.php
@@ -12,7 +12,6 @@ use Drupal\Core\Menu\MenuTreeStorageInterface;
 /**
  * Overrides the default menu tree storage so we can access private data.
  */
-
 class WorkbenchAccessMenuStorage extends MenuTreeStorage implements MenuTreeStorageInterface {
 
   /**

--- a/src/WorkbenchAccessServiceProvider.php
+++ b/src/WorkbenchAccessServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * @file
+ * Contains \Drupal\workbench_access\WorkbenchAccessServiceProvider.
+ */
+
+namespace Drupal\workbench_access;
+
+use Drupal\Core\DependencyInjection\ContainerBuilder;
+use Drupal\Core\DependencyInjection\ServiceModifierInterface;
+use Drupal\Core\DependencyInjection\ServiceProviderBase;
+use Drupal\workbench_access\WorkbenchAccessMenuStorage;
+
+/**
+ * Makes the menu tree storage service public.
+ */
+class WorkbenchAccessServiceProvider extends ServiceProviderBase implements ServiceModifierInterface {
+  /**
+   * {@inheritdoc}
+   */
+  public function alter(ContainerBuilder $container) {
+    // We have to load full menu data, which has to be done from the private
+    // menu.tree_storage service. See core_services.yml.
+    $definition = $container->getDefinition('menu.tree_storage');
+    $definition->setPublic(TRUE);
+    $definition->setClass(WorkbenchAccessMenuStorage::class);
+  }
+
+}
+


### PR DESCRIPTION
This PR is a bit larger than hoped, because while it corrects the filter behavior for Views, it also addressed #31.

We found that the menu id keys, which have dots in them, cannot be used in forms, so it is likely better to use the numeric MLID key.

Problem is, that's a private property on a private service. So we had to make the service public and then change the definition of fields it should return.
