### PR TITLE
Apply access control to moderation.

### DIFF
--- a/config/install/workbench_access.settings.yml
+++ b/config/install/workbench_access.settings.yml
@@ -4,3 +4,4 @@ label: Section
 plural_label: Sections
 fields: {}
 deny_on_empty: false
+apply_to_moderation: false

--- a/config/schema/workbench_access.schema.yml
+++ b/config/schema/workbench_access.schema.yml
@@ -14,6 +14,9 @@ workbench_access.settings:
     deny_on_empty:
       type: boolean
       label: 'Deny access to unassigned content'
+    apply_to_moderation:
+      type: boolean
+      label: 'Apply access rules to moderation forms'
     label:
       type: text
       label: 'Label shown to define a Workbench Access control group.'

--- a/src/AccessControlHierarchyBase.php
+++ b/src/AccessControlHierarchyBase.php
@@ -263,6 +263,26 @@ abstract class AccessControlHierarchyBase extends PluginBase implements AccessCo
   /**
    * {@inheritdoc}
    */
+  public function checkModerationAccess(EntityInterface $entity, AccountInterface $account, WorkbenchAccessManagerInterface $manager) {
+    /** @var \Drupal\node\NodeTypeInterface $type */
+    $active = FALSE;
+    if ($type = $this->entityTypeManager->getStorage('node_type')->load($entity->bundle())) {
+      $active = $type->getThirdPartySetting('workbench_access', 'workbench_access_status', 0);
+    }
+    if (!$active) {
+      return TRUE;
+    }
+    // Check that the user can update the entity.
+    $accessResult = $this->checkEntityAccess($entity, 'update', $account, $manager);
+    // Our access check only returns Neutral or Forbidden, so we return the reverse of
+    // isForbidden() since we are setting #access to true or false on the element.
+    // See workbench_access_entity_view_alter().
+    return !$accessResult->isForbidden();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function getEntityValues(EntityInterface $entity, $field) {
     $values = [];
     foreach ($entity->get($field)->getValue() as $item) {

--- a/src/AccessControlHierarchyBase.php
+++ b/src/AccessControlHierarchyBase.php
@@ -262,10 +262,14 @@ abstract class AccessControlHierarchyBase extends PluginBase implements AccessCo
 
   /**
    * {@inheritdoc}
+   *
+   * @TODO: find a better way to deal with the $manager.
+   * @TODO: write tests.
    */
   public function checkModerationAccess(EntityInterface $entity, AccountInterface $account, WorkbenchAccessManagerInterface $manager) {
-    /** @var \Drupal\node\NodeTypeInterface $type */
+    // @TODO: Move this duplicate code to a method.
     $active = FALSE;
+    /** @var \Drupal\node\NodeTypeInterface $type */
     if ($type = $this->entityTypeManager->getStorage('node_type')->load($entity->bundle())) {
       $active = $type->getThirdPartySetting('workbench_access', 'workbench_access_status', 0);
     }

--- a/src/AccessControlHierarchyInterface.php
+++ b/src/AccessControlHierarchyInterface.php
@@ -131,6 +131,8 @@ interface AccessControlHierarchyInterface {
    *
    * @param EntityInterface $entity
    *   The node being checked. In future this may handle other entity types.
+   * @param $op
+   *   The operation being performed.
    * @param AccountInterface $account
    *   The user requesting access to the node.
    * @param WorkbenchAccessManagerInterface $manager
@@ -142,6 +144,22 @@ interface AccessControlHierarchyInterface {
    * @see workbench_access_node_access()
    */
   public function checkEntityAccess(EntityInterface $entity, $op, AccountInterface $account, WorkbenchAccessManagerInterface $manager);
+
+  /**
+   * Responds to request for node moderation.
+   *
+   * @param EntityInterface $entity
+   *   The node being checked. In future this may handle other entity types.
+   * @param AccountInterface $account
+   *   The user requesting access to the node.
+   * @param WorkbenchAccessManagerInterface $manager
+   *   The access control manager.
+   *
+   * @return boolean
+   *
+   * @see workbench_access_entity_view_alter()
+   */
+  public function checkModerationAccess(EntityInterface $entity, AccountInterface $account, WorkbenchAccessManagerInterface $manager);
 
   /**
    * Alters the selection options provided for an access control field.

--- a/src/Form/WorkbenchAccessConfigForm.php
+++ b/src/Form/WorkbenchAccessConfigForm.php
@@ -173,6 +173,12 @@ class WorkbenchAccessConfigForm extends ConfigFormBase {
       '#default_value' => $config->get('deny_on_empty', 0),
       '#description' => $this->t('For content under access control, deny access for any content not assigned to a section. This setting is off by default so that installing the module does not break existing site behavior.'),
     ];
+    $form['behavior']['apply_to_moderation'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Apply to content moderation'),
+      '#default_value' => $config->get('apply_to_moderation', 0),
+      '#description' => $this->t('Apply access rules to moderation forms for content under access control.'),
+    ];
     $form['labels'] = [
       '#type' => 'details',
       '#title' => $this->t('Labels'),
@@ -201,6 +207,7 @@ class WorkbenchAccessConfigForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->config('workbench_access.settings');
     $config->set('deny_on_empty', $form_state->getValue('deny_on_empty'))
+      ->set('apply_to_moderation', $form_state->getValue('apply_to_moderation'))
       ->set('label', $form_state->getValue('label'))
       ->set('plural_label', $form_state->getValue('plural_label'));
     $new_scheme = $form_state->getValue('scheme');

--- a/workbench_access.install
+++ b/workbench_access.install
@@ -44,3 +44,12 @@ function workbench_access_update_8001() {
   $config->save(TRUE);
 }
 
+/**
+ * Add the setting to enable access on moderation forms.
+ */
+function workbench_access_update_8002() {
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('workbench_access.settings');
+  $config->set('apply_to_moderation', 0);
+  $config->save(TRUE);
+}

--- a/workbench_access.module
+++ b/workbench_access.module
@@ -8,6 +8,8 @@
 use Drupal\node\NodeTypeInterface;
 use Drupal\node\NodeInterface;
 use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\Core\Session\AccountInterface;
@@ -196,6 +198,29 @@ function workbench_access_node_create_access(AccountInterface $account, $context
     return AccessResult::forbidden();
   }
   return $return;
+}
+
+/**
+ * Implements hook_entity_view_alter().
+ *
+ * Allow or deny access to the moderation entity form displayed on content view.
+ */
+function workbench_access_entity_view_alter(&$build, EntityInterface $entity, EntityViewDisplayInterface $display) {
+  // Only applies to nodes and when enabled.
+  $restriction_enabled = \Drupal::config('workbench_access.settings')->get('apply_to_moderation');
+  if (!$restriction_enabled || $entity->getEntityTypeId() != 'node') {
+    return;
+  }
+  // Supports both content_moderation and workbench_moderation, which use similar code.
+  foreach (['content_moderation_control', 'workbench_moderation_control'] as $element) {
+    if (isset($build[$element])) {
+      $account = \Drupal::currentUser();
+      $manager = \Drupal::service('plugin.manager.workbench_access.scheme');
+      if ($scheme = $manager->getActiveScheme()) {
+        $build[$element]['#access'] = $scheme->checkModerationAccess($entity, $account, $manager);
+      }
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
This should work for both content moderation and workbench moderation.

@larowlan I think my big question for core is -- why is this access control not handled through entity access? This code seems like a huge hack, when we should just an a 'moderate' $op to access checks.