### PR TITLE
Fixes #80

### DIFF
--- a/tests/src/Kernel/NodeAccessTest.php
+++ b/tests/src/Kernel/NodeAccessTest.php
@@ -97,8 +97,12 @@ class NodeAccessTest extends KernelTestBase {
     $allowed_editor->{WorkbenchAccessManagerInterface::FIELD_NAME} = $term->id();
     $allowed_editor->save();
     $editor_with_no_access = $this->createUser($permissions);
+    $permissions[] = 'bypass workbench access';
+    $editor_with_bypass_access = $this->createUser($permissions);
+
     $this->assertTrue($this->accessHandler->createAccess('page', $allowed_editor));
     $this->assertFalse($this->accessHandler->createAccess('page', $editor_with_no_access));
+    $this->assertTrue($this->accessHandler->createAccess('page', $editor_with_bypass_access));
   }
 
   /**

--- a/workbench_access.module
+++ b/workbench_access.module
@@ -178,6 +178,11 @@ function workbench_access_node_access(NodeInterface $node, $op, AccountInterface
  */
 function workbench_access_node_create_access(AccountInterface $account, $context, $entity_bundle) {
   $return = AccessResult::neutral();
+  // User can bypass.
+  if ($account->hasPermission('bypass workbench access')) {
+    return $return;
+  }
+
   // Check that our access control is configured.
   $manager = \Drupal::service('plugin.manager.workbench_access.scheme');
   if (!$manager->getActiveScheme()) {


### PR DESCRIPTION
Issue #2904003 by larowlan: workbench_access_node_create_access() doesn't respect bypass workbench access permission

Fixes #80 - see https://drupal.org/node/2904003