### PR TITLE
Issue #2946725 by acbramley: Deny on empty setting not retained in up…

### DIFF
--- a/tests/src/Functional/UpdatePathTest.php
+++ b/tests/src/Functional/UpdatePathTest.php
@@ -24,7 +24,12 @@ class UpdatePathTest extends UpdatePathTestBase {
    * Tests workbench_access_update_8002().
    */
   public function testUpdatePath() {
+    $expected_new_config = [
+      'deny_on_empty' => \Drupal::config('workbench_access.settings')->get('deny_on_empty'),
+      '_core' => \Drupal::config('workbench_access.settings')->get('_core'),
+    ];
     $this->runUpdates();
+    $this->assertEquals($expected_new_config, \Drupal::config('workbench_access.settings')->getRawData());
     $this->assertEquals('default', $this->container->get('state')->get('workbench_access_upgraded_scheme_id'));
     /** @var \Drupal\workbench_access\Entity\AccessSchemeInterface $scheme */
     $entity_type_manager = $this->container->get('entity_type.manager');

--- a/workbench_access.install
+++ b/workbench_access.install
@@ -55,7 +55,7 @@ function workbench_access_update_8002() {
   // Alter it to the new format.
   $config = \Drupal::configFactory()->getEditable('workbench_access.settings');
   foreach (['scheme', 'label', 'plural_label', 'fields', 'parents'] as $delete) {
-    $config->delete();
+    $config->clear($delete);
   }
   $config->save(TRUE);
 }


### PR DESCRIPTION
See https://www.drupal.org/project/workbench_access/issues/2946725

This would need to go into the d.o. branch first, I think, so we can release the last alpha. However, this test is against the new code.