### PR TITLE
Tab perms

### DIFF
--- a/src/Form/AssignUserForm.php
+++ b/src/Form/AssignUserForm.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\workbench_access\Form;
 
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Config\Entity\ConfigEntityStorageInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
@@ -96,6 +98,20 @@ class AssignUserForm extends FormBase {
       $container->get('workbench_access.user_section_storage'),
       $container->get('workbench_access.role_section_storage')
     );
+  }
+  /**
+   * Checks access to the form from the route.
+   *
+   * This form is only visible on accounts that can use Workbench Access,
+   * regardless of the current user's permissions.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   The account accessing the form.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user being edited.
+   */
+  public function access(AccountInterface $account, AccountInterface $user) {
+    return AccessResult::allowedIf($user->hasPermission('use workbench access'));
   }
 
   /**

--- a/tests/src/Functional/AssignUserFormTest.php
+++ b/tests/src/Functional/AssignUserFormTest.php
@@ -139,8 +139,45 @@ class AssignUserFormTest extends BrowserTestBase {
     ], 'none');
     $none_user = $this->createUserWithRole($none_rid);
 
+    // No workbench.
+    $empty_rid = $this->createRole([
+      'create page content',
+      'edit any page content',
+      'delete any page content',
+      'create article content',
+      'edit any article content',
+      'delete any article content',
+      'access user profiles',
+    ], 'empty');
+    $empty_user = $this->createUserWithRole($empty_rid);
+
     // Check page access.
+
+    // As normal user.
+    $this->drupalLogin($empty_user);
+    $this->drupalGet(Url::fromRoute('entity.section_association.edit', ['user' => $none_user->id()]));
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(403);
+
+    // As low-level admin.
+    $this->drupalLogin($partial_user);
+    $this->drupalGet(Url::fromRoute('entity.section_association.edit', ['user' => $empty_user->id()]));
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(403);
+
+    $this->drupalGet(Url::fromRoute('entity.section_association.edit', ['user' => $none_user->id()]));
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(200);
+
+    // As admin user.
     $this->drupalLogin($admin_user);
+
+    // The page for a user without Workbench Access should by 403.
+    $this->drupalGet(Url::fromRoute('entity.section_association.edit', ['user' => $empty_user->id()]));
+    $assert = $this->assertSession();
+    $assert->statusCodeEquals(403);
+
+    // Get the page for a normal user.
     $this->drupalGet(Url::fromRoute('entity.section_association.edit', ['user' => $none_user->id()]));
     $assert = $this->assertSession();
     $assert->statusCodeEquals(200);

--- a/workbench_access.routing.yml
+++ b/workbench_access.routing.yml
@@ -36,6 +36,7 @@ entity.section_association.edit:
     _form: 'Drupal\workbench_access\Form\AssignUserForm'
     _title: 'Workbench Access'
   requirements:
+    _custom_access: 'Drupal\workbench_access\Form\AssignUserForm::access'
     _permission: 'assign workbench access+assign selected workbench access'
   options:
     _admin_route: TRUE


### PR DESCRIPTION
The tab on the user page is handled incorrectly. It should not exist for accounts that do not have the `use workbench access` permission, regardless of the permissions of the current user.