### PR TITLE
Expose section views data to revisions

### DIFF
--- a/src/Plugin/AccessControlHierarchy/Taxonomy.php
+++ b/src/Plugin/AccessControlHierarchy/Taxonomy.php
@@ -285,6 +285,23 @@ class Taxonomy extends AccessControlHierarchyBase {
           ],
         ];
       }
+      if (($revision_table = $entity_type->getRevisionTable()) && ($id = $entity_type->getKey('id'))) {
+        $data[$revision_table]['workbench_access_section__' . $scheme->id()] = [
+          'title' => t('Workbench access @name', ['@name' => $scheme->label()]),
+          'help' => t('The sections to which this content belongs in the @name scheme.', [
+            '@name' => $scheme->label(),
+          ]),
+          'field' => [
+            'scheme' => $scheme->id(),
+            'id' => 'workbench_access_section',
+          ],
+          'filter' => [
+            'field' => $id,
+            'scheme' => $scheme->id(),
+            'id' => 'workbench_access_section',
+          ],
+        ];
+      }
     }
   }
 

--- a/src/Plugin/AccessControlHierarchy/Taxonomy.php
+++ b/src/Plugin/AccessControlHierarchy/Taxonomy.php
@@ -277,6 +277,7 @@ class Taxonomy extends AccessControlHierarchyBase {
           'field' => [
             'scheme' => $scheme->id(),
             'id' => 'workbench_access_section',
+            'click sortable' => TRUE,
           ],
           'filter' => [
             'field' => $id,
@@ -294,6 +295,7 @@ class Taxonomy extends AccessControlHierarchyBase {
           'field' => [
             'scheme' => $scheme->id(),
             'id' => 'workbench_access_section',
+            'click sortable' => TRUE,
           ],
           'filter' => [
             'field' => $id,


### PR DESCRIPTION
This is a work-in-progress.

To my understanding, to make the Workbench Access filter work with Content Moderation, we have to be able to filter on content revisions. This starts that work, but the logic in `Drupal\workbench_access\Plugin\views\filter\Section::query()` will need to be updated to account for the tables.