### PR TITLE
The user section page eats memory

### DIFF
--- a/src/UserSectionStorage.php
+++ b/src/UserSectionStorage.php
@@ -205,13 +205,22 @@ class UserSectionStorage implements UserSectionStorageInterface {
    * issues. Try to filter at the query level.
    *
    * @param array $users
-   *   An array of users keyed by id.
+   *   An array of users keyed by id with names as the value.
    * @return array
+   *   An array of users keyed by id with names as the value.
+   *
+   * @deprecated and will be removed before the 8.x-1.0 stable release.
+   *   Instead, you should filter at the query level by using role permissions.
+   *
+   * @see UserSectionStorage::getPotentialEditors()
    *
    * @link
    *   https://www.drupal.org/project/workbench_access/issues/3025466
    */
   protected function filterByPermission($users = []) {
+    @trigger_error('UserSectionStorage::filterByPermission() is deprecated and
+      will be removed before the 8.x-1.0 stable release. Instead, you should
+      filter at the query level by using role permissions.');
     $list = [];
     if (!empty($users)) {
       $entities = $this->userStorage()->loadMultiple($users);

--- a/src/UserSectionStorage.php
+++ b/src/UserSectionStorage.php
@@ -174,7 +174,7 @@ class UserSectionStorage implements UserSectionStorageInterface {
    */
   public function getPotentialEditors($id) {
     // Get all role IDs that have the configured permissions.
-    $roles = user_role_names(TRUE, 'use workbench access');
+    $roles = user_role_names(FALSE, 'use workbench access');
     // user_role_names() returns an array with the role IDs as keys, so take
     // the array keys and merge them with previously found role IDs.
     $rids = array_keys($roles);
@@ -187,7 +187,7 @@ class UserSectionStorage implements UserSectionStorageInterface {
     $users = $query->execute();
     // The anon user is not in the database.
     if (in_array(AccountInterface::ANONYMOUS_ROLE, $rids, TRUE)) {
-      $users[0] = 0;
+      $users[0] = '0';
     }
     return $users;
   }


### PR DESCRIPTION
https://www.drupal.org/project/workbench_access/issues/3025466

When we have a high volume of users (> 1000 or so), the current way of checking `getPotentialEditors` is a performance nightmare because it runs a user load on every value. 

We can filter that at the query level. 