### PR TITLE
Code style updates

### DIFF
--- a/workbench_access_protect/src/Access/DeleteAccessCheck.php
+++ b/workbench_access_protect/src/Access/DeleteAccessCheck.php
@@ -18,13 +18,6 @@ use Drupal\workbench_access\Entity\AccessSchemeInterface;
 class DeleteAccessCheck implements DeleteAccessCheckInterface {
 
   /**
-   * User account.
-   *
-   * @var \Drupal\Core\Session\AccountInterface
-   */
-  private $account;
-
-  /**
    * Default object for current_route_match service.
    *
    * @var \Drupal\Core\Routing\CurrentRouteMatch

--- a/workbench_access_protect/tests/src/Functional/TaxonomyProtectTest.php
+++ b/workbench_access_protect/tests/src/Functional/TaxonomyProtectTest.php
@@ -159,7 +159,6 @@ class TaxonomyProtectTest extends BrowserTestBase {
    */
   protected function setUpTestUser() {
     $user_storage = \Drupal::service('workbench_access.user_section_storage');
-    $role_storage = \Drupal::service('workbench_access.role_section_storage');
     // Add the user to the base section.
     $user_storage->addUser($this->scheme, $this->editor, [$this->term->id()]);
     $expected = [$this->editor->id()];

--- a/workbench_access_protect/workbench_access_protect.api.php
+++ b/workbench_access_protect/workbench_access_protect.api.php
@@ -24,5 +24,7 @@
 function hook_workbench_access_protect_list_alter(array &$list) {
   // Our example module uses node types as the access scheme. They have no
   // parents.
-  $list['node_type'] => ['node_type'];
+  return [
+    $list['node_type'] => ['node_type'],
+  ];
 }


### PR DESCRIPTION
- Removes the unused private `account` property from the `DeleteAccessCheck` class.
- Removes the unused `$role_storage` local variable assignment from `setUpTestUser()`
- Corrects the syntax for returning an array in `workbench_access_protect.api.php`