### PR TITLE
Better handling of AccessCacheTest

### DIFF
--- a/src/AccessControlHierarchyBase.php
+++ b/src/AccessControlHierarchyBase.php
@@ -136,6 +136,19 @@ abstract class AccessControlHierarchyBase extends PluginBase implements AccessCo
   }
 
   /**
+   * Gets the entity type id controlled by the scheme.
+   *
+   * Note that this is an API change and not in the Interface.
+   * @TODO: add to interface in version 2.0.
+   *
+   * @return string
+   *  The entity type id of entities controlled by the scheme.
+   */
+  public function entityType() {
+    return $this->pluginDefinition['entity'];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function calculateDependencies() {

--- a/workbench_access.module
+++ b/workbench_access.module
@@ -67,6 +67,25 @@ function workbench_access_entity_access(EntityInterface $entity, $op, AccountInt
 }
 
 /**
+ * Implements hook_entity_delete().
+ */
+function workbench_access_entity_delete(EntityInterface $entity) {
+  foreach (\Drupal::entityTypeManager()->getStorage('access_scheme')->loadMultiple() as $scheme) {
+    $entity_type = $scheme->getAccessScheme()->entityType();
+    if ($entity_type === $entity->getEntityTypeId()) {
+      // Delete all associated storage.
+      $section_storage = \Drupal::entityTypeManager()->getStorage('section_association');
+      $sections = $section_storage->loadByProperties([
+        'access_scheme' => $scheme->id(),
+        'section_id' => $entity->id(),
+      ]);
+      $section_storage->delete($sections);
+      \Drupal::service('workbench_access.user_section_storage')->resetCache($scheme);
+    }
+  }
+}
+
+/**
  * Implements hook_node_create_access().
  *
  * @link https://www.drupal.org/node/2348203


### PR DESCRIPTION
https://www.drupal.org/project/workbench_access/issues/3156122

This also adds an implementation of hook_entity_delete() so that we can remove section associations when an entity is deleted.

@larowlan Can you take a look at this?